### PR TITLE
add suport for containerized rjserver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tower-lsp = "0.20"
 
 [[bin]]
-name = "rustyjsonserver"
+name = "rjserver"
 path = "src/main.rs"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tower-lsp = "0.20"
 
 [[bin]]
-name = "rjserver"
+name = "rustyjsonserver"
 path = "src/main.rs"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN --mount=type=bind,source=./src,target=/app/src \
     --mount=type=cache,target=/app/target/ \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
-    cargo build --locked --release --bin rustyjsonserver && \
-    cp ./target/release/rustyjsonserver /bin/server
+    cargo build --locked --release --bin rjserver && \
+    cp ./target/release/rjserver /bin/server
 
 # Create a new stage for running the application.
 
@@ -25,17 +25,15 @@ FROM alpine:3.18 AS final
 # Create the directory for the application.
 RUN mkdir -p /app
 
-# Copy the executable and configuration file from the "build" stage.
+# Copy the executable from the "build" stage.
 COPY --from=build /bin/server /bin/
-COPY ./config.json /app/config.json
 
 # Expose the port that the application listens on.
 EXPOSE 8080
 
-# test connectivity with netcat: install and listen on port 5555
-# RUN apk add --no-cache netcat-openbsd
-# CMD ["nc", "-l", "5555"] 
+# Use a bind mount for the configuration file.
+# The config file should be mounted at /app/config.json at runtime.
 
-# run: rjserver serve --config config.json
+# run: rjserver serve --config /app/config.json
 ENTRYPOINT ["/bin/server"]
 CMD ["serve", "--config", "/app/config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+ARG RUST_VERSION=1.91.1
+
+FROM rust:${RUST_VERSION}-alpine AS build
+WORKDIR /app
+
+# Install host build dependencies.
+RUN apk add --no-cache clang lld musl-dev git
+
+# Build the app
+RUN --mount=type=bind,source=./src,target=/app/src \
+    --mount=type=bind,source=./Cargo.toml,target=/app/Cargo.toml \
+    --mount=type=bind,source=./Cargo.lock,target=/app/Cargo.lock \
+    --mount=type=cache,target=/app/target/ \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    cargo build --locked --release --bin rustyjsonserver && \
+    cp ./target/release/rustyjsonserver /bin/server
+
+# Create a new stage for running the application.
+
+FROM alpine:3.18 AS final
+
+# Create the directory for the application.
+RUN mkdir -p /app
+
+# Copy the executable and configuration file from the "build" stage.
+COPY --from=build /bin/server /bin/
+COPY ./config.json /app/config.json
+
+# Expose the port that the application listens on.
+EXPOSE 8080
+
+# test connectivity with netcat: install and listen on port 5555
+# RUN apk add --no-cache netcat-openbsd
+# CMD ["nc", "-l", "5555"] 
+
+# run: rjserver serve --config config.json
+ENTRYPOINT ["/bin/server"]
+CMD ["serve", "--config", "/app/config.json"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ Create **`config.json`**:
 
 * As Binary: `rjserver.exe serve --config config.json`
 
-* As Docker image: build image `docker build -t <IMAGE_NAME> .` , run image  `docker run --rm -p 8080:8080 <IMAGE_NAME>`
+* As Docker image: build image `docker build -t <IMAGE_NAME> .` , run image  `docker run --rm -p 8080:8080 -v $(pwd)/config.json:/app/config.json <IMAGE_NAME>`
 
 Access:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,9 +36,9 @@ Create **`config.json`**:
 
 ## 3. Start the server
 
-```
-rjserver.exe serve --config config.json
-```
+* As Binary: `rjserver.exe serve --config config.json`
+
+* As Docker image: build image `docker build -t <IMAGE_NAME> .` , run image  `docker run --rm -p 8080:8080 <IMAGE_NAME>`
 
 Access:
 


### PR DESCRIPTION
 Address issue #2 
<img width="2804" height="1658" alt="Screenshot 2025-12-02 at 22 17 55" src="https://github.com/user-attachments/assets/a0af270d-0e02-4098-906e-359ee515b56d" />

* Server is starting correctly, but it is binding to `127.0.0.1:5555`, which means it's only accessible from within the container. Investigate making it accessible externally;  binding inside the container to  `0.0.0.0:5555.`